### PR TITLE
Update plugin.py

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -405,7 +405,8 @@ class WallboxPlugin:
         if currentValue.isnumeric():
             newValue = int(currentValue) + delta
         
-        myUnit.sValue = f"{chargingCurrent * 1000};{str(newValue)}"
+        ## myUnit.sValue = f"{chargingCurrent * 1000};{str(newValue)}"
+        myUnit.sValue = f"{str(0)};{str(newValue)}"
         myUnit.nValue = 0
         myUnit.Update(Log=True)
 

--- a/plugin.py
+++ b/plugin.py
@@ -246,9 +246,9 @@ class WallboxPlugin:
             },
             { #5
                 "Unit": self.DEVICECURRENT,
-                "Name": "Charging current",
-                "Type": 243,
-                "Subtype": 23,
+                "Name": "Charging Power",
+                "Type": 248,
+                "Subtype": 1,
             },
             { #6
                 "Unit": self.DEVICESTARTSTOP,
@@ -351,14 +351,14 @@ class WallboxPlugin:
             myUnit.Update(Log=True)
             Domoticz.Debug('Charging status changed to: ' + chargingStatus)
 
-        ## 5: Charging current
+        ## 5: Charging current (This is represented in kW), not in 'A' what 'current' is.
         myUnit = Devices[chargerId].Units[self.DEVICECURRENT]
-        chargingCurrent = str(round(chargerStatus["charging_power"],1))
-        sValue = f"{chargingCurrent};{chargingCurrent}"
+        chargingCurrent = str(round(chargerStatus["charging_power"]*1000,1))
+        sValue = f"{chargingCurrent}"
         if myUnit.sValue != sValue:
             myUnit.sValue = sValue
             myUnit.Update(Log=True)
-            Domoticz.Debug('Charging current changed to: ' + chargingCurrent)
+            Domoticz.Debug('Charging Power changed to: ' + chargingCurrent)
         
         ## 6: Charging stop start
         myUnit = Devices[chargerId].Units[self.DEVICESTARTSTOP]


### PR DESCRIPTION
Based on issue as described here: https://github.com/lokonli/domoticz-wallbox/issues/3

I don't think the correct data is being pushed to Domoticz correctly.

As a workaround created this patch. 
Now all the 00000000 are not stored in the specific Total Energy device in Domoticz. It just stores 0;<value>.